### PR TITLE
Implement link parser modules and content fetcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@larksuiteoapi/node-sdk": "^1.0.0",
     "axios": "^1.6.0",
     "body-parser": "^1.20.2",
+    "cheerio": "^1.0.0-rc.12",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "mongoose": "^8.0.0",
@@ -36,4 +37,4 @@
   },
   "author": "",
   "license": "MIT"
-} 
+}

--- a/src/bot/__tests__/FeishuBot.test.js
+++ b/src/bot/__tests__/FeishuBot.test.js
@@ -2,7 +2,17 @@ const FeishuBot = require('../FeishuBot');
 const config = require('../../config');
 
 // Mock dependencies
-jest.mock('@larksuiteoapi/node-sdk');
+jest.mock('@larksuiteoapi/node-sdk', () => {
+  return {
+    Client: jest.fn().mockImplementation(() => ({
+      im: {
+        message: {
+          create: jest.fn(),
+        },
+      },
+    })),
+  };
+});
 jest.mock('../../utils/logger');
 jest.mock('../../config', () => ({
   feishu: {
@@ -10,6 +20,13 @@ jest.mock('../../config', () => ({
     appSecret: 'test_app_secret',
     verificationToken: 'test_token',
     encryptKey: 'test_key',
+  },
+  logging: {
+    filePath: 'logs/test.log',
+    level: 'info',
+  },
+  server: {
+    env: 'test',
   },
 }));
 

--- a/src/parser/__tests__/linkExtractor.test.js
+++ b/src/parser/__tests__/linkExtractor.test.js
@@ -1,0 +1,33 @@
+const LinkExtractor = require('../linkExtractor');
+
+describe('LinkExtractor', () => {
+  let extractor;
+
+  beforeEach(() => {
+    extractor = new LinkExtractor();
+  });
+
+  test('extracts multiple links and classifies platforms', () => {
+    const text = '看看这个 https://mp.weixin.qq.com/s/abc123 和这个 https://www.zhihu.com/question/12345 还有 https://www.bilibili.com/video/BV1 以及重复 https://mp.weixin.qq.com/s/abc123';
+    const links = extractor.extract(text);
+    expect(links).toEqual([
+      { url: 'https://mp.weixin.qq.com/s/abc123', platform: 'weixin', category: 'work' },
+      { url: 'https://www.zhihu.com/question/12345', platform: 'zhihu', category: 'work' },
+      { url: 'https://www.bilibili.com/video/BV1', platform: 'bilibili', category: 'other' },
+    ]);
+  });
+
+  test('returns empty array for no links', () => {
+    expect(extractor.extract('hello world')).toEqual([]);
+  });
+
+  test('reset clears deduplication state', () => {
+    const text = 'https://example.com';
+    extractor.extract(text);
+    expect(extractor.extract(text)).toEqual([]);
+    extractor.reset();
+    expect(extractor.extract(text)).toEqual([
+      { url: 'https://example.com', platform: 'unknown', category: 'other' },
+    ]);
+  });
+});

--- a/src/parser/__tests__/linkValidator.test.js
+++ b/src/parser/__tests__/linkValidator.test.js
@@ -1,0 +1,24 @@
+const LinkValidator = require('../linkValidator');
+const axios = require('axios');
+
+jest.mock('axios');
+
+describe('LinkValidator', () => {
+  let validator;
+
+  beforeEach(() => {
+    validator = new LinkValidator();
+  });
+
+  test('valid link returns metadata', async () => {
+    axios.get.mockResolvedValue({ status: 200, data: '<title>Test</title>' });
+    const result = await validator.validate('https://mp.weixin.qq.com/s/abc');
+    expect(result).toEqual({ valid: true, status: 200, type: 'weixin', title: 'Test' });
+  });
+
+  test('invalid link returns false', async () => {
+    axios.get.mockRejectedValue({ response: { status: 404 } });
+    const result = await validator.validate('https://example.com');
+    expect(result).toEqual({ valid: false, status: 404, type: 'unknown', title: '' });
+  });
+});

--- a/src/parser/linkExtractor.js
+++ b/src/parser/linkExtractor.js
@@ -1,0 +1,56 @@
+const urlRegex = /https?:\/\/[\w.-]+(?:\.[\w\.-]+)+(?:[\/?#][^\s]*)?/gi;
+
+const platformPatterns = {
+  weixin: /https?:\/\/mp\.weixin\.qq\.com\/[^\s]+/i,
+  zhihu: /https?:\/\/(?:zhuanlan\.|www\.)?zhihu\.com\/[^\s]+/i,
+  bilibili: /https?:\/\/(?:www\.)?bilibili\.com\/[^\s]+/i,
+};
+
+class LinkExtractor {
+  constructor() {
+    this.seenLinks = new Set();
+  }
+
+  /**
+   * 提取文本中的链接并分类
+   * @param {string} text 文本内容
+   * @returns {Array<{url: string, platform: string, category: 'work'|'other'}>}
+   */
+  extract(text) {
+    if (!text) return [];
+    const matches = text.match(urlRegex) || [];
+    const results = [];
+
+    for (const url of matches) {
+      const normalized = url.replace(/[.,\u3002]+$/g, '');
+      if (this.seenLinks.has(normalized)) continue;
+      this.seenLinks.add(normalized);
+      const platform = this.detectPlatform(normalized);
+      const category = ['weixin', 'zhihu'].includes(platform) ? 'work' : 'other';
+      results.push({ url: normalized, platform, category });
+    }
+
+    return results;
+  }
+
+  /**
+   * 根据链接判断所属平台
+   * @param {string} url 链接
+   * @returns {string}
+   */
+  detectPlatform(url) {
+    if (platformPatterns.weixin.test(url)) return 'weixin';
+    if (platformPatterns.zhihu.test(url)) return 'zhihu';
+    if (platformPatterns.bilibili.test(url)) return 'bilibili';
+    return 'unknown';
+  }
+
+  /**
+   * 清除已记录的链接（用于新消息会话）
+   */
+  reset() {
+    this.seenLinks.clear();
+  }
+}
+
+module.exports = LinkExtractor;

--- a/src/parser/linkValidator.js
+++ b/src/parser/linkValidator.js
@@ -1,0 +1,29 @@
+const axios = require('axios');
+const LinkExtractor = require('./linkExtractor');
+
+const extractor = new LinkExtractor();
+
+class LinkValidator {
+  constructor() {
+    this.extractor = extractor;
+  }
+
+  /**
+   * 验证链接有效性并提取元数据
+   * @param {string} url 链接
+   * @returns {Promise<{valid: boolean, status: number, type: string, title: string}>}
+   */
+  async validate(url) {
+    const type = this.extractor.detectPlatform(url);
+    try {
+      const res = await axios.get(url, { timeout: 5000 });
+      const titleMatch = res.data.match(/<title>([^<]*)<\/title>/i);
+      const title = titleMatch ? titleMatch[1] : '';
+      return { valid: true, status: res.status, type, title };
+    } catch (err) {
+      return { valid: false, status: err.response?.status || 0, type, title: '' };
+    }
+  }
+}
+
+module.exports = LinkValidator;

--- a/src/services/__tests__/contentFetcher.test.js
+++ b/src/services/__tests__/contentFetcher.test.js
@@ -1,0 +1,31 @@
+const fetcher = require('../contentFetcher');
+const axios = require('axios');
+
+jest.mock('axios');
+
+describe('contentFetcher', () => {
+  beforeEach(() => {
+    fetcher.clear();
+  });
+
+  test('fetches and cleans content', async () => {
+    const html = '<html><head><title>t</title></head><body><h1>Hello</h1><script></script></body></html>';
+    axios.get.mockResolvedValue({ data: html });
+    const text = await fetcher.fetch('https://example.com');
+    expect(text).toBe('Hello');
+  });
+
+  test('returns cached content', async () => {
+    const html = '<html><body>Hi</body></html>';
+    axios.get.mockResolvedValue({ data: html });
+    const text1 = await fetcher.fetch('https://example.com');
+    axios.get.mockResolvedValue({ data: '<html><body>New</body></html>' });
+    const text2 = await fetcher.fetch('https://example.com');
+    expect(text2).toBe(text1);
+  });
+
+  test('throws error on failure', async () => {
+    axios.get.mockRejectedValue(new Error('fail'));
+    await expect(fetcher.fetch('https://bad.com')).rejects.toThrow('内容抓取失败');
+  });
+});

--- a/src/services/contentFetcher.js
+++ b/src/services/contentFetcher.js
@@ -1,0 +1,39 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+
+class ContentFetcher {
+  constructor() {
+    this.cache = new Map();
+  }
+
+  /**
+   * 获取并清理网页内容
+   * @param {string} url 链接
+   * @returns {Promise<string>} 纯文本内容
+   */
+  async fetch(url) {
+    if (this.cache.has(url)) {
+      return this.cache.get(url);
+    }
+
+    try {
+      const res = await axios.get(url, { timeout: 5000 });
+      const $ = cheerio.load(res.data);
+      $('script, style, noscript').remove();
+      const text = $('body').text().replace(/\s+/g, ' ').trim();
+      this.cache.set(url, text);
+      return text;
+    } catch (err) {
+      throw new Error('内容抓取失败');
+    }
+  }
+
+  /**
+   * 清理缓存
+   */
+  clear() {
+    this.cache.clear();
+  }
+}
+
+module.exports = new ContentFetcher();


### PR DESCRIPTION
## Summary
- implement LinkExtractor for URL detection and categorisation
- add LinkValidator to check URL accessibility and extract title
- introduce ContentFetcher service with caching
- test coverage for new modules and updated FeishuBot tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841420600b88328b34e29015119da72