### PR TITLE
Add summarizer module and AI service tests

### DIFF
--- a/src/services/__tests__/ai.test.js
+++ b/src/services/__tests__/ai.test.js
@@ -1,0 +1,37 @@
+let OpenAI;
+// AIService will be required after mocks are set up
+
+jest.mock('openai', () => ({ OpenAI: jest.fn() }));
+jest.mock('../../utils/logger');
+jest.mock('../../config', () => ({
+  siliconflow: { apiKey: 'k', baseUrl: 'u', model: 'm' },
+  openai: { apiKey: 'k' },
+  feishu: { appId: 'id', appSecret: 's', verificationToken: 't' },
+  logging: { level: 'info', filePath: 'logs/app.log' },
+  server: { env: 'test' },
+}));
+
+describe('AIService', () => {
+  let createMock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    OpenAI = require('openai').OpenAI;
+    createMock = jest.fn().mockResolvedValue({ choices: [{ message: { content: ' result ' } }] });
+    OpenAI.mockImplementation(() => ({ chat: { completions: { create: createMock } } }));
+  });
+
+  test('generateSummary passes style', async () => {
+    const ai = require('../ai');
+    const summary = await ai.generateSummary('text', { style: 'paragraph' });
+    const call = createMock.mock.calls[0][0];
+    expect(call.messages[0].content).toContain('简洁段落');
+    expect(summary).toBe('result');
+  });
+
+  test('generateSummary throws on error', async () => {
+    createMock.mockRejectedValue(new Error('bad'));
+    const ai = require('../ai');
+    await expect(ai.generateSummary('a')).rejects.toThrow('生成摘要失败');
+  });
+});

--- a/src/services/ai.js
+++ b/src/services/ai.js
@@ -15,14 +15,16 @@ class AIService {
    * @param {string} content - 文章内容
    * @returns {Promise<string>} 生成的摘要
    */
-  async generateSummary(content) {
+  async generateSummary(content, options = {}) {
+    const style = options.style || 'bullet';
+    const styleText = style === 'bullet' ? '请用条目形式' : '请用简洁段落';
     try {
       const response = await this.client.chat.completions.create({
         model: config.siliconflow.model,
         messages: [
           {
             role: 'system',
-            content: '你是一个专业的文章摘要生成助手。请用简洁的语言总结文章的主要内容，突出关键信息。',
+            content: `你是一个专业的文章摘要生成助手。${styleText}总结文章的主要内容，突出关键信息。`,
           },
           {
             role: 'user',

--- a/src/summarizer/__tests__/summarizer.test.js
+++ b/src/summarizer/__tests__/summarizer.test.js
@@ -1,0 +1,55 @@
+jest.mock('../../config', () => ({
+  feishu: { appId: 'id', appSecret: 's', verificationToken: 't' },
+  siliconflow: { apiKey: 'k', baseUrl: 'u', model: 'm' },
+  openai: { apiKey: 'k' },
+  logging: { level: 'info', filePath: 'logs/app.log' },
+  server: { env: 'test' },
+}));
+jest.mock('../../services/ai');
+jest.mock('../../services/contentFetcher');
+jest.mock('../../utils/logger');
+
+const Summarizer = require('../summarizer');
+const aiService = require('../../services/ai');
+const contentFetcher = require('../../services/contentFetcher');
+const logger = require('../../utils/logger');
+
+describe('Summarizer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('summarizes url with given style', async () => {
+    const summarizer = new Summarizer({ retries: 1, style: 'bullet' });
+    contentFetcher.fetch.mockResolvedValue('content');
+    aiService.generateSummary.mockResolvedValue('summary');
+
+    const result = await summarizer.summarize('http://a.com', { style: 'paragraph' });
+
+    expect(contentFetcher.fetch).toHaveBeenCalledWith('http://a.com');
+    expect(aiService.generateSummary).toHaveBeenCalledWith('content', { style: 'paragraph' });
+    expect(result).toBe('summary');
+  });
+
+  test('retries on failure', async () => {
+    const summarizer = new Summarizer({ retries: 1 });
+    contentFetcher.fetch.mockResolvedValue('data');
+    aiService.generateSummary
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce('ok');
+
+    const result = await summarizer.summarize('http://b.com');
+
+    expect(aiService.generateSummary).toHaveBeenCalledTimes(2);
+    expect(result).toBe('ok');
+  });
+
+  test('throws after exceeding retries', async () => {
+    const summarizer = new Summarizer({ retries: 1 });
+    contentFetcher.fetch.mockResolvedValue('c');
+    aiService.generateSummary.mockRejectedValue(new Error('err'));
+
+    await expect(summarizer.summarize('http://c.com')).rejects.toThrow('err');
+    expect(aiService.generateSummary).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/summarizer/summarizer.js
+++ b/src/summarizer/summarizer.js
@@ -1,0 +1,29 @@
+const aiService = require('../services/ai');
+const contentFetcher = require('../services/contentFetcher');
+const logger = require('../utils/logger');
+
+class Summarizer {
+  constructor(options = {}) {
+    this.maxRetries = options.retries ?? 2;
+    this.defaultStyle = options.style ?? 'bullet';
+  }
+
+  async summarize(url, options = {}) {
+    const style = options.style || this.defaultStyle;
+    const content = await contentFetcher.fetch(url);
+    let attempt = 0;
+    while (true) {
+      try {
+        return await aiService.generateSummary(content, { style });
+      } catch (err) {
+        attempt += 1;
+        logger.warn('Summary generation failed', err);
+        if (attempt > this.maxRetries) {
+          throw err;
+        }
+      }
+    }
+  }
+}
+
+module.exports = Summarizer;


### PR DESCRIPTION
## Summary
- implement Summarizer class for generating article summaries with retry logic
- allow style option in AIService.generateSummary
- add unit tests for AIService and Summarizer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68414a7318648328a7a9a8f9d60d521e