### PR TITLE
Add demo mode with mock data

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,18 @@ npm install
 ```bash
 cp .env.example .env
 # 编辑 .env 文件，填入必要的配置信息
+# 如需演示模式，可将 ENABLE_MOCK_DATA 设置为 true
 ```
 
 4. 启动开发服务器
 ```bash
 npm run dev
 ```
+
+## 演示模式
+
+当 `ENABLE_MOCK_DATA` 设置为 `true` 时，应用将生成演示用的链接和摘要。
+启动后访问 `/demo/mock-data` 即可获取示例数据。
 
 ## 项目结构
 

--- a/src/mock/__tests__/mockData.test.js
+++ b/src/mock/__tests__/mockData.test.js
@@ -1,0 +1,13 @@
+const mockData = require('../mockData');
+
+describe('mockData', () => {
+  test('returns links with summaries', () => {
+    const data = mockData.getMockLinksWithSummaries();
+    expect(data.length).toBeGreaterThan(0);
+    data.forEach(item => {
+      expect(item.url).toBeDefined();
+      expect(item.title).toBeDefined();
+      expect(item.summary).toContain(item.url);
+    });
+  });
+});

--- a/src/mock/mockData.js
+++ b/src/mock/mockData.js
@@ -1,0 +1,23 @@
+const sampleLinks = [
+  { url: 'https://example.com/article1', title: '示例文章一' },
+  { url: 'https://example.com/article2', title: '示例文章二' },
+  { url: 'https://example.com/video1', title: '示例视频一' },
+];
+
+function getMockLinks() {
+  return sampleLinks;
+}
+
+function getMockSummary(url, style = 'bullet') {
+  const prefix = style === 'bullet' ? '• ' : '';
+  return `${prefix}这是 ${url} 的摘要演示`;
+}
+
+function getMockLinksWithSummaries(style = 'bullet') {
+  return sampleLinks.map((link) => ({
+    ...link,
+    summary: getMockSummary(link.url, style),
+  }));
+}
+
+module.exports = { getMockLinks, getMockSummary, getMockLinksWithSummaries };

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,7 @@ const bodyParser = require('body-parser');
 const FeishuBot = require('./bot/FeishuBot');
 const logger = require('./utils/logger');
 const config = require('./config');
+const mockData = require('./mock/mockData');
 
 class Server {
   constructor() {
@@ -59,6 +60,12 @@ class Server {
         res.status(500).json({ error: 'Internal server error' });
       }
     });
+
+    if (config.features.enableMockData) {
+      this.app.get('/demo/mock-data', (req, res) => {
+        res.json({ links: mockData.getMockLinksWithSummaries() });
+      });
+    }
   }
 
   start() {

--- a/src/summarizer/__tests__/summarizer.test.js
+++ b/src/summarizer/__tests__/summarizer.test.js
@@ -4,6 +4,7 @@ jest.mock('../../config', () => ({
   openai: { apiKey: 'k' },
   logging: { level: 'info', filePath: 'logs/app.log' },
   server: { env: 'test' },
+  features: { enableMockData: false },
 }));
 jest.mock('../../services/ai');
 jest.mock('../../services/contentFetcher');
@@ -50,5 +51,15 @@ describe('Summarizer', () => {
 
     await expect(summarizer.summarize('http://c.com')).rejects.toThrow('err');
     expect(aiService.generateSummary).toHaveBeenCalledTimes(2);
+  });
+
+  test('uses mock data when enabled', async () => {
+    const config = require('../../config');
+    config.features.enableMockData = true;
+    const summarizer = new Summarizer();
+    const mockData = require('../../mock/mockData');
+    const result = await summarizer.summarize('http://demo.com');
+    expect(result).toBe(mockData.getMockSummary('http://demo.com', 'bullet'));
+    expect(aiService.generateSummary).not.toHaveBeenCalled();
   });
 });

--- a/src/summarizer/summarizer.js
+++ b/src/summarizer/summarizer.js
@@ -1,6 +1,8 @@
 const aiService = require('../services/ai');
 const contentFetcher = require('../services/contentFetcher');
 const logger = require('../utils/logger');
+const config = require('../config');
+const mockData = require('../mock/mockData');
 
 class Summarizer {
   constructor(options = {}) {
@@ -10,6 +12,9 @@ class Summarizer {
 
   async summarize(url, options = {}) {
     const style = options.style || this.defaultStyle;
+    if (config.features.enableMockData) {
+      return mockData.getMockSummary(url, style);
+    }
     const content = await contentFetcher.fetch(url);
     let attempt = 0;
     while (attempt <= this.maxRetries) {


### PR DESCRIPTION
## Summary
- enable optional mock data mode via config
- include demo data generator
- return mock summaries when mock mode is enabled
- expose `/demo/mock-data` route
- document demo mode in README
- test mock data functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684164f53d248328b3e2f4c654f2203b