### PR TITLE
Extend link extractor for more platforms

### DIFF
--- a/src/parser/__tests__/linkExtractor.test.js
+++ b/src/parser/__tests__/linkExtractor.test.js
@@ -8,12 +8,15 @@ describe('LinkExtractor', () => {
   });
 
   test('extracts multiple links and classifies platforms', () => {
-    const text = '看看这个 https://mp.weixin.qq.com/s/abc123 和这个 https://www.zhihu.com/question/12345 还有 https://www.bilibili.com/video/BV1 以及重复 https://mp.weixin.qq.com/s/abc123';
+    const text =
+      '看看这个 https://mp.weixin.qq.com/s/abc123 和这个 https://www.zhihu.com/question/12345 还有 https://www.bilibili.com/video/BV1 \n以及 https://v.douyin.com/xyz 和 https://www.xiaohongshu.com/explore/abc 以及重复 https://mp.weixin.qq.com/s/abc123';
     const links = extractor.extract(text);
     expect(links).toEqual([
-      { url: 'https://mp.weixin.qq.com/s/abc123', platform: 'weixin', category: 'work' },
-      { url: 'https://www.zhihu.com/question/12345', platform: 'zhihu', category: 'work' },
-      { url: 'https://www.bilibili.com/video/BV1', platform: 'bilibili', category: 'other' },
+      { url: 'https://mp.weixin.qq.com/s/abc123', platform: 'weixin', category: 'work', tags: ['article'] },
+      { url: 'https://www.zhihu.com/question/12345', platform: 'zhihu', category: 'work', tags: ['article'] },
+      { url: 'https://www.bilibili.com/video/BV1', platform: 'bilibili', category: 'other', tags: ['video'] },
+      { url: 'https://v.douyin.com/xyz', platform: 'douyin', category: 'other', tags: ['video'] },
+      { url: 'https://www.xiaohongshu.com/explore/abc', platform: 'xiaohongshu', category: 'other', tags: ['social'] },
     ]);
   });
 
@@ -27,7 +30,7 @@ describe('LinkExtractor', () => {
     expect(extractor.extract(text)).toEqual([]);
     extractor.reset();
     expect(extractor.extract(text)).toEqual([
-      { url: 'https://example.com', platform: 'unknown', category: 'other' },
+      { url: 'https://example.com', platform: 'unknown', category: 'other', tags: [] },
     ]);
   });
 });

--- a/src/parser/linkExtractor.js
+++ b/src/parser/linkExtractor.js
@@ -4,6 +4,17 @@ const platformPatterns = {
   weixin: /https?:\/\/mp\.weixin\.qq\.com\/[^\s]+/i,
   zhihu: /https?:\/\/(?:zhuanlan\.|www\.)?zhihu\.com\/[^\s]+/i,
   bilibili: /https?:\/\/(?:www\.)?bilibili\.com\/[^\s]+/i,
+  douyin: /https?:\/\/(?:v|www)\.douyin\.com\/[^\s]+/i,
+  xiaohongshu: /https?:\/\/www\.xiaohongshu\.com\/[^\s]+/i,
+};
+
+const platformMeta = {
+  weixin: { category: 'work', tags: ['article'] },
+  zhihu: { category: 'work', tags: ['article'] },
+  bilibili: { category: 'other', tags: ['video'] },
+  douyin: { category: 'other', tags: ['video'] },
+  xiaohongshu: { category: 'other', tags: ['social'] },
+  unknown: { category: 'other', tags: [] },
 };
 
 class LinkExtractor {
@@ -14,7 +25,7 @@ class LinkExtractor {
   /**
    * 提取文本中的链接并分类
    * @param {string} text 文本内容
-   * @returns {Array<{url: string, platform: string, category: 'work'|'other'}>}
+   * @returns {Array<{url: string, platform: string, category: string, tags: string[]}>}
    */
   extract(text) {
     if (!text) return [];
@@ -26,8 +37,8 @@ class LinkExtractor {
       if (this.seenLinks.has(normalized)) continue;
       this.seenLinks.add(normalized);
       const platform = this.detectPlatform(normalized);
-      const category = ['weixin', 'zhihu'].includes(platform) ? 'work' : 'other';
-      results.push({ url: normalized, platform, category });
+      const meta = platformMeta[platform] || platformMeta.unknown;
+      results.push({ url: normalized, platform, category: meta.category, tags: meta.tags });
     }
 
     return results;
@@ -42,6 +53,8 @@ class LinkExtractor {
     if (platformPatterns.weixin.test(url)) return 'weixin';
     if (platformPatterns.zhihu.test(url)) return 'zhihu';
     if (platformPatterns.bilibili.test(url)) return 'bilibili';
+    if (platformPatterns.douyin.test(url)) return 'douyin';
+    if (platformPatterns.xiaohongshu.test(url)) return 'xiaohongshu';
     return 'unknown';
   }
 

--- a/src/server/__tests__/server.test.js
+++ b/src/server/__tests__/server.test.js
@@ -5,6 +5,7 @@ jest.mock('../../config', () => ({
   feishu: { appId: 'id', appSecret: 'sec', verificationToken: 'token' },
   logging: { level: 'info', filePath: 'logs/app.log' },
   server: { env: 'test', port: 3000 },
+  features: { enableMockData: false },
 }));
 
 const FeishuBot = require('../../bot/FeishuBot');


### PR DESCRIPTION
## Summary
- support douyin and xiaohongshu links
- return tags along with platform and category
- fix server tests by mocking feature flags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842bb4d817883289e12bff25e378eea