### PR TITLE
Add demo mode tests

### DIFF
--- a/src/mock/mockData.js
+++ b/src/mock/mockData.js
@@ -2,6 +2,9 @@ const sampleLinks = [
   { url: 'https://example.com/article1', title: '示例文章一' },
   { url: 'https://example.com/article2', title: '示例文章二' },
   { url: 'https://example.com/video1', title: '示例视频一' },
+  { url: 'https://mp.weixin.qq.com/s/abc123', title: '微信文章示例' },
+  { url: 'https://www.zhihu.com/question/12345', title: '知乎问题示例' },
+  { url: 'https://www.bilibili.com/video/BV1', title: 'B站视频示例' },
 ];
 
 function getMockLinks() {


### PR DESCRIPTION
## Summary
- expand mock data with common platform links
- mock config features in server tests
- cover demo route for enabled/disabled cases

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842bb5296048328b9f3b3300f288bd0